### PR TITLE
refactor: block client side promotions

### DIFF
--- a/cl_jobs.lua
+++ b/cl_jobs.lua
@@ -52,7 +52,7 @@ AddEventHandler('randol_multijob:client:choiceMenu', function(args)
                 description = ('Switch your job to: %s'):format(args.jobLabel),
                 icon = 'fa-solid fa-circle-check',
                 onSelect = function()
-                    TriggerServerEvent('randol_multijob:server:changeJob', args.job, args.grade)
+                    TriggerServerEvent('randol_multijob:server:changeJob', args.job)
                     Wait(100)
                     ExecuteCommand('myjobs')
                 end,


### PR DESCRIPTION
By letting the client tell us what grade they want to be they could be dirty hackers and promote themselves. This blocks that behavior.

Includes additional changes for the sql to block duplicate cid/job rows and to only set player to unemployed if they deleted their current job.